### PR TITLE
Added note for tectonic based matchbox example

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -112,6 +112,7 @@ Environment="MATCHBOX_RPC_ADDRESS=0.0.0.0:8081"
 ```
 
 The Tectonic [Installer](https://tectonic.com/enterprise/docs/latest/install/bare-metal/index.html) uses this API. Tectonic users with a CoreOS provisioner can start with an example that enables it.
+*Note: rkt must already be installed before using this example*
 
 ```sh
 $ sudo cp contrib/systemd/matchbox-for-tectonic.service /etc/systemd/system/matchbox.service


### PR DESCRIPTION
docs: Add note on line 115

Using an rpm based installation rkt is not installed prior to starting the matchbox service which causes the service to fail.